### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+dist: trusty
+script: bundle exec rake test
+
+matrix:
+  include:
+  - os: linux
+    rvm: 2.3.4
+  - os: osx
+    rvm: 2.3.4
+  - os: linux
+    rvm: 2.4.0
+  - os: osx
+    rvm: 2.4.0
+  fast_finish: true
+

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
 # Jsonnet
 
-Jsonnet processor library.  Wraps the official C++ implementation with a Ruby extension library.
+[Jsonnet][] processor library.  Wraps the official C++ implementation with a Ruby extension library.
 
 ## Installation
-
-Install libjsonnet:
-
-    $ git clone https://github.com/google/jsonnet.git
-    $ cd jsonnet
-    $ make libjsonnet.so
-    $ sudo cp libjsonnet.so /usr/local/lib/libjsonnet.so
-    $ sudo cp include/libjsonnet.h /usr/local/include/libjsonnet.h
 
 Add this line to your application's Gemfile:
 
@@ -20,11 +12,50 @@ gem 'jsonnet'
 
 And then execute:
 
-    $ bundle
+```shell
+$ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install jsonnet
+```shell
+$ gem install jsonnet
+```
+
+By default this gem will compile and install Jsonnet (v0.9.4) as part of
+installation. However you can use the system version of Jsonnet if you prefer.
+This would be the recommended route if you want to use a different version
+of Jsonnet or are having problems installing this.
+
+To install libjsonnet:
+
+```shell
+$ git clone https://github.com/google/jsonnet.git
+$ cd jsonnet
+$ make libjsonnet.so
+$ sudo cp libjsonnet.so /usr/local/lib/libjsonnet.so
+$ sudo cp include/libjsonnet.h /usr/local/include/libjsonnet.h
+```
+
+Note: /usr/local/lib and /usr/local/include are used as they are library lookup
+locations. You may need to adjust these for your system if you have errors
+running this gem saying it can't open libjsonnet.so - on Ubuntu for instance
+I found /lib worked when /usr/local/lib did not.
+
+To install this gem without jsonnet:
+
+Use `JSONNET_USE_SYSTEM_LIBRARIES` ENV var:
+
+```shell
+$ JSONNET_USE_SYSTEM_LIBRARIES=1 bundle install
+```
+
+or, the `--use-system-libraries` option:
+
+
+```shell
+gem install jsonnet -- --use-system-libraries
+```
 
 ## Usage
 
@@ -37,3 +68,5 @@ TODO: Write usage instructions here
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+[Jsonnet]: https://github.com/google/jsonnet

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Install libjsonnet:
 
     $ git clone https://github.com/google/jsonnet.git
     $ cd jsonnet
-    $ make
+    $ make libjsonnet.so
     $ sudo cp libjsonnet.so /usr/local/lib/libjsonnet.so
-    $ sudo cp libjsonnet.h /usr/local/include/libjsonnet.h
+    $ sudo cp include/libjsonnet.h /usr/local/include/libjsonnet.h
 
 Add this line to your application's Gemfile:
 

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -1,6 +1,55 @@
 require 'mkmf'
+require 'fileutils'
+
+def using_system_libraries?
+  arg_config('--use-system-libraries', !!ENV['JSONNET_USE_SYSTEM_LIBRARIES'])
+end
 
 dir_config('jsonnet')
+
+unless using_system_libraries?
+  message "Building jsonnet using packaged libraries.\n"
+  require 'rubygems'
+  gem 'mini_portile2', '~> 2.2.0'
+  require 'mini_portile2'
+  message "Using mini_portile version #{MiniPortile::VERSION}\n"
+
+  recipe = MiniPortile.new('jsonnet', 'v0.9.4')
+  recipe.files = ['https://github.com/google/jsonnet/archive/v0.9.4.tar.gz']
+  class << recipe
+
+    def compile
+      # We want to create a file a library we can link to. Jsonnet provides us
+      # with the command `make libjsonnet.so` which creates a shared object
+      # however that won't be bundled into the compiled output so instead
+      # we compile the c into .o files and then create an archive that can
+      # be linked to
+      execute('compile', make_cmd)
+      execute('archive', 'ar rcs libjsonnet.a core/desugarer.o core/formatter.o core/lexer.o core/libjsonnet.o core/parser.o core/pass.o core/static_analysis.o core/string_utils.o core/vm.o third_party/md5/md5.o')
+    end
+
+    def configured?
+      true
+    end
+
+    def install
+      lib_path = File.join(port_path, 'lib')
+      include_path = File.join(port_path, 'include')
+
+      FileUtils.mkdir_p([lib_path, include_path])
+
+      FileUtils.cp(File.join(work_path, 'libjsonnet.a'), lib_path)
+      FileUtils.cp(File.join(work_path, 'include', 'libjsonnet.h'), include_path)
+    end
+  end
+
+  recipe.cook
+  # I tried using recipe.activate here but that caused this file to build ok
+  # but the makefile to fail. These commands add the necessary paths to do both
+  $LIBPATH = ["#{recipe.path}/lib"] | $LIBPATH
+  $CPPFLAGS << " -I#{recipe.path}/include"
+end
+
 abort 'libjsonnet.h not found' unless have_header('libjsonnet.h')
 abort 'libjsonnet not found' unless have_library('jsonnet')
 create_makefile('jsonnet/jsonnet_wrap')

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -48,6 +48,12 @@ unless using_system_libraries?
   # but the makefile to fail. These commands add the necessary paths to do both
   $LIBPATH = ["#{recipe.path}/lib"] | $LIBPATH
   $CPPFLAGS << " -I#{recipe.path}/include"
+
+  # This resolves an issue where you can get improper linkage when compiling
+  # and get an error like "undefined symbol: _ZTVN10__cxxabiv121__vmi_class_type_infoE"
+  # experienced on ubuntu.
+  # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=193950
+  $LIBS << " -lstdc++"
 end
 
 abort 'libjsonnet.h not found' unless have_header('libjsonnet.h')

--- a/ext/jsonnet/jsonnet.c
+++ b/ext/jsonnet/jsonnet.c
@@ -343,15 +343,6 @@ vm_set_max_trace(VALUE self, VALUE val)
     return Qnil;
 }
 
-static VALUE
-vm_set_debug_ast(VALUE self, VALUE val)
-{
-    struct jsonnet_vm_wrap *vm;
-    TypedData_Get_Struct(self, struct jsonnet_vm_wrap, &jsonnet_vm_type, vm);
-    jsonnet_debug_ast(vm->vm, RTEST(val));
-    return Qnil;
-}
-
 void
 Init_jsonnet_wrap(void)
 {
@@ -371,7 +362,6 @@ Init_jsonnet_wrap(void)
     rb_define_method(cVM, "gc_growth_trigger=", vm_set_gc_growth_trigger, 1);
     rb_define_method(cVM, "string_output=", vm_set_string_output, 1);
     rb_define_method(cVM, "max_trace=", vm_set_max_trace, 1);
-    rb_define_method(cVM, "debug_ast=", vm_set_debug_ast, 1);
     rb_define_method(cVM, "import_callback=", vm_set_import_callback, 1);
 
     eEvaluationError = rb_define_class_under(mJsonnet, "EvaluationError", rb_eRuntimeError);

--- a/ext/jsonnet/jsonnet.c
+++ b/ext/jsonnet/jsonnet.c
@@ -259,7 +259,7 @@ import_callback_thunk(void *ctx, const char *base, const char *rel, char **found
 /**
  * Sets a custom way to resolve "import" expression.
  * @param [#call] callback receives two parameters and returns two values.
- *                The first parameter "base" is a base directory to resolve 
+ *                The first parameter "base" is a base directory to resolve
  *                "rel" from.
  *                The second parameter "rel" is an absolute or a relative
  *                path to the file to import.

--- a/jsonnet.gemspec
+++ b/jsonnet.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "mini_portile2", "~>2.2.0"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit", "~> 3.1.3"

--- a/lib/jsonnet/vm.rb
+++ b/lib/jsonnet/vm.rb
@@ -11,9 +11,9 @@ module Jsonnet
     # @raise [EvaluationError] raised when the evaluation results an error.
     # @raise [UnsupportedEncodingError] raised when the encoding of jsonnet
     #        is not ASCII-compatible.
-    # @note It is recommended to encode the source string in UTF-8 because 
-    #       Jsonnet expects it is ASCII-compatible, the result JSON string 
-    #       shall be UTF-{8,16,32} according to RFC 7159 thus the only 
+    # @note It is recommended to encode the source string in UTF-8 because
+    #       Jsonnet expects it is ASCII-compatible, the result JSON string
+    #       shall be UTF-{8,16,32} according to RFC 7159 thus the only
     #       intersection between the requirements is UTF-8.
     def evaluate(jsonnet, filename: "(jsonnet)", multi: false)
       eval_snippet(jsonnet, filename, multi)
@@ -26,9 +26,9 @@ module Jsonnet
     # @param [Boolean] multi    enables multi-mode
     # @return [String] a JSON representation of the evaluation result
     # @raise [EvaluationError] raised when the evaluation results an error.
-    # @note It is recommended to encode the source file in UTF-8 because 
-    #       Jsonnet expects it is ASCII-compatible, the result JSON string 
-    #       shall be UTF-{8,16,32} according to RFC 7159 thus the only 
+    # @note It is recommended to encode the source file in UTF-8 because
+    #       Jsonnet expects it is ASCII-compatible, the result JSON string
+    #       shall be UTF-{8,16,32} according to RFC 7159 thus the only
     #       intersection between the requirements is UTF-8.
     def evaluate_file(filename, encoding: Encoding.default_external, multi: false)
       eval_file(filename, encoding, multi)

--- a/test/test_vm.rb
+++ b/test/test_vm.rb
@@ -225,7 +225,7 @@ class TestVM < Test::Unit::TestCase
       case [base, rel]
       when ['/path/to/base/', 'imported1.jsonnet']
         return <<-EOS, '/path/to/imported1/imported1.jsonnet'
-          import "imported2.jsonnet" {
+          (import "imported2.jsonnet") + {
             b: 2,
           }
         EOS
@@ -238,7 +238,7 @@ class TestVM < Test::Unit::TestCase
       end
     }
     result = vm.evaluate(<<-EOS, filename: "/path/to/base/example.jsonnet")
-      import "imported1.jsonnet" { c: 3 }
+      (import "imported1.jsonnet") + { c: 3 }
     EOS
 
     expected = {"a" => 1, "b" => 2, "c" => 3}
@@ -251,7 +251,7 @@ class TestVM < Test::Unit::TestCase
     vm.import_callback = ->(base, rel) { called = true; raise }
     assert_raise(Jsonnet::EvaluationError) {
       vm.evaluate(<<-EOS)
-        import "a.jsonnet" {}
+        (import "a.jsonnet") + {}
       EOS
     }
     assert_true called

--- a/test/test_vm.rb
+++ b/test/test_vm.rb
@@ -211,10 +211,6 @@ class TestVM < Test::Unit::TestCase
     Jsonnet::VM.new.max_trace = 1
   end
 
-  test "Jsonnet::VM responds to debug_ast=" do
-    Jsonnet::VM.new.debug_ast = true
-  end
-
   test "Jsonnet::VM#string_output lets the VM output a raw string" do
     vm = Jsonnet::VM.new
     vm.string_output = true

--- a/test/test_vm.rb
+++ b/test/test_vm.rb
@@ -47,7 +47,7 @@ class TestVM < Test::Unit::TestCase
     vm = Jsonnet::VM.new
     begin
       with_example_file(%q{ ["unterminated string }) {|fname|
-        vm.evaluate_file(fname.encode(Encoding::SJIS)) 
+        vm.evaluate_file(fname.encode(Encoding::SJIS))
       }
     rescue Jsonnet::EvaluationError => e
       assert_equal Encoding::SJIS, e.message.encoding
@@ -104,7 +104,7 @@ class TestVM < Test::Unit::TestCase
   test "Jsonnet::VM#evaluate raises an error in the encoding of filename" do
     vm = Jsonnet::VM.new
     begin
-      vm.evaluate(%Q{ ["unterminated string }, filename: "テスト.json".encode(Encoding::SJIS)) 
+      vm.evaluate(%Q{ ["unterminated string }, filename: "テスト.json".encode(Encoding::SJIS))
     rescue Jsonnet::EvaluationError => e
       assert_equal Encoding::SJIS, e.message.encoding
     end


### PR DESCRIPTION
This PR is dependent on https://github.com/yugui/ruby-jsonnet/pull/2 I just didn't include this with it in case using Travis CI was a more controversial choice than anticipated. Since you need to have jsonnet compiled and installed you pretty much need the contents of that PR

This just adds a .travis.yml script so future builds can be tested against Travis CI. You can view a build [here](https://travis-ci.org/kevindew/ruby-jsonnet/builds/248533874)