### PR TITLE
Add a top level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,31 @@ gem install jsonnet -- --use-system-libraries
 
 ## Usage
 
-TODO: Write usage instructions here
+Load the library with `require "jsonnet"`
+
+You can evaluate a string of Jsonnet using `Jsonnet.parse`
+
+```
+irb(main):002:0> Jsonnet.evaluate('{ foo: "bar" }')
+=> {"foo"=>"bar"}
+```
+Or load a file using `Jsonnet.load`
+
+```
+irb(main):002:0> Jsonnet.load('example.jsonnet')
+=> {"baz"=>1}
+```
+
+To get closer to the C++ interface you can create an instance of `Jsonnet::VM`
+
+```
+irb(main):002:0> vm = Jsonnet::VM.new
+=> #<Jsonnet::VM:0x007fd29aa1e568>
+irb(main):003:0> vm.evaluate('{ foo: "bar" }')
+=> "{\n   \"foo\": \"bar\"\n}\n"
+irb(main):004:0> vm.evaluate_file('example.jsonnet')
+=> "{\n   \"baz\": 1\n}\n"
+```
 
 ## Contributing
 

--- a/ext/jsonnet/jsonnet.c
+++ b/ext/jsonnet/jsonnet.c
@@ -322,7 +322,7 @@ vm_set_gc_growth_trigger(VALUE self, VALUE val)
 }
 
 /*
- * Let #evalutae and #evaluate_file return a raw String instead of JSON-encoded string if val is true
+ * Let #evaluate and #evaluate_file return a raw String instead of JSON-encoded string if val is true
  * @param [Boolean] val
  */
 static VALUE

--- a/lib/jsonnet.rb
+++ b/lib/jsonnet.rb
@@ -1,7 +1,49 @@
 require "jsonnet/version"
 require "jsonnet/jsonnet_wrap"
 require "jsonnet/vm"
+require "jsonnet/evaluator"
+require "json"
 
 module Jsonnet
-  # Your code goes here...
+  module_function
+
+  ##
+  # Evaluates a string of Jsonnet and returns a hash of the resulting JSON
+  #
+  # @param [String]  jsonnet  Jsonnet source string, ideally in UTF-8 encoding
+  # @param [Hash]    jsonnet_options A hash of options to for Jsonnet::VM.
+  #                                  Available options are: filename, multi,
+  #                                  import_callback, gc_growth_triger,
+  #                                  gc_min_objects, max_stack, max_trace
+  # @param [Hash]    json_options Options supported by {JSON.parse}[http://www.rubydoc.info/github/flori/json/JSON#parse-class_method]
+  # @return [Hash] The JSON representation as a hash
+  # @raise [UnsupportedOptionError] Raised when an option passed is unsupported by Jsonnet::VM
+  #
+  # @note This method runs Jsonnet::VM#evaluate and runs the string
+  #       output through {JSON.parse}[http://www.rubydoc.info/github/flori/json/JSON#parse-class_method]
+  #       so those should be looked at for furhter details
+  def evaluate(jsonnet, jsonnet_options: {}, json_options: {})
+    output = Evaluator.from_snippet(jsonnet, jsonnet_options)
+    JSON.parse(output, json_options)
+  end
+
+  ##
+  # Loads a Jsonnet file and returns a hash of the resulting JSON
+  #
+  # @param [String]  path path to the jsonnet file
+  # @param [Hash]    jsonnet_options A hash of options to for Jsonnet::VM.
+  #                                  Available options are: encoding, multi,
+  #                                  import_callback, gc_growth_triger,
+  #                                  gc_min_objects, max_stack, max_trace
+  # @param [Hash]    json_options Options supported by {JSON.parse}[http://www.rubydoc.info/github/flori/json/JSON#parse-class_method]
+  # @return [Hash] The JSON representation as a hash
+  # @raise [UnsupportedOptionError] Raised when an option passed is unsupported by Jsonnet::VM
+  #
+  # @note This method runs Jsonnet::VM#evaluate_file and runs the string
+  #       output through {JSON.parse}[http://www.rubydoc.info/github/flori/json/JSON#parse-class_method]
+  #       so those should be looked at for furhter details
+  def load(path, jsonnet_options: {}, json_options: {})
+    output = Evaluator.from_file(path, jsonnet_options)
+    JSON.parse(output, json_options)
+  end
 end

--- a/lib/jsonnet/evaluator.rb
+++ b/lib/jsonnet/evaluator.rb
@@ -1,0 +1,46 @@
+module Jsonnet
+  class Evaluator
+    def self.from_snippet(snippet, options = {})
+      snippet_check = ->(key, value) { key.to_s.match(/^filename|multi$/) }
+      snippet_options = options.select &snippet_check
+      vm_options = options.reject &snippet_check
+      self.new(vm_options).snippet(snippet, snippet_options)
+    end
+
+    def self.from_file(filename, options = {})
+      file_check = ->(key, value) { key.to_s.match(/^encoding|multi$/) }
+      file_options = options.select &file_check
+      vm_options = options.reject &file_check
+      self.new(vm_options).file(filename, file_options)
+    end
+
+    def initialize(options = {})
+      @vm = Jsonnet::VM.new
+      apply_options(options)
+    end
+
+    def snippet(snippet, options = {})
+      vm.evaluate(snippet, options)
+    end
+
+    def file(filename, options = {})
+      vm.evaluate_file(filename, options)
+    end
+
+  private
+    attr_reader :vm
+
+    def apply_options(options)
+      options.each do |key, value|
+        method = "#{key}="
+        if vm.respond_to?(method)
+          vm.public_send(method, value)
+        else
+          raise UnsupportedOptionError.new("Jsonnet VM does not support #{key} option")
+        end
+      end
+    end
+
+    class UnsupportedOptionError < RuntimeError; end
+  end
+end

--- a/test/test_jsonnet.rb
+++ b/test/test_jsonnet.rb
@@ -1,8 +1,51 @@
 require 'jsonnet'
+
+require 'tempfile'
 require 'test/unit'
 
 class TestJsonnet < Test::Unit::TestCase
   test 'libversion returns a String' do
-    assert_kind_of String, Jsonnet.libversion 
+    assert_kind_of String, Jsonnet.libversion
+  end
+
+  test 'Jsonnet.evaluate returns a JSON parsed result' do
+    result = Jsonnet.evaluate('{ foo: "bar" }')
+    assert_equal result, { "foo" => "bar" }
+  end
+
+  test 'Jsonnet.evaluate can accept options for JSON' do
+    result = Jsonnet.evaluate('{ foo: "bar" }', json_options: { symbolize_names: true })
+    assert_equal result, { foo: "bar" }
+  end
+
+  test 'Jsonnet.evaluate can accept options for Jsonnet VM' do
+    result = Jsonnet.evaluate(
+      'import "imported.jsonnet"',
+      jsonnet_options: {
+        import_callback: ->(_base, _rel) do
+          return ['{ foo: "bar" }', 'imported']
+        end
+      }
+    )
+    assert_equal result, { "foo" => "bar" }
+  end
+
+  test 'Jsonnet.load returns a JSON parsed result' do
+    result = Jsonnet.load(example_jsonnet_file.path)
+    assert_equal result, { "foo1" => 1 }
+  end
+
+  private
+
+  def example_jsonnet_file
+    example = Tempfile.open("example.jsonnet") do |f|
+      f.write %<
+        local myvar = 1;
+        {
+          ["foo" + myvar]: myvar,
+        }
+      >
+      f
+    end
   end
 end


### PR DESCRIPTION
This PR aims to make it easier to use Jsonnet in Ruby projects by adding a simpler API.

It adds two module functions to `Jsonnet` of `.parse` and `.load` (naming inspired by [Ruby JSON](https://ruby-doc.org/stdlib-2.4.0/libdoc/json/rdoc/JSON.html)) which initialise the `Jsonnet::VM` and run the output through `JSON.parse`. This gives you a simpler, nicer interface to load in Jsonnet files.

It also adds usage instructions for the README