### PR TITLE
Relax version constraint of mini_portile2

### DIFF
--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -10,7 +10,6 @@ dir_config('jsonnet')
 unless using_system_libraries?
   message "Building jsonnet using packaged libraries.\n"
   require 'rubygems'
-  gem 'mini_portile2', '~> 2.2.0'
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 

--- a/jsonnet.gemspec
+++ b/jsonnet.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mini_portile2", "~>2.2.0"
+  spec.add_runtime_dependency "mini_portile2", ">= 2.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I've tested with mini_portile2 v2.3.0.
I think there's no reason to specify upper-bound.