### PR TITLE
Update bundled jsonnet to v0.10.0

### DIFF
--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -13,8 +13,8 @@ unless using_system_libraries?
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
-  recipe = MiniPortile.new('jsonnet', 'v0.9.4')
-  recipe.files = ['https://github.com/google/jsonnet/archive/v0.9.4.tar.gz']
+  recipe = MiniPortile.new('jsonnet', 'v0.10.0')
+  recipe.files = ['https://github.com/google/jsonnet/archive/v0.10.0.tar.gz']
   class << recipe
 
     def compile


### PR DESCRIPTION
Release notes:

- https://github.com/google/jsonnet/releases/tag/v0.9.5
- https://github.com/google/jsonnet/releases/tag/v0.10.0