### PR TITLE
Update bundled jsonnet to v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 $ gem install jsonnet
 ```
 
-By default this gem will compile and install Jsonnet (v0.13.0) as part of
+By default this gem will compile and install Jsonnet (v0.16.0) as part of
 installation. However you can use the system version of Jsonnet if you prefer.
 This would be the recommended route if you want to use a different version
 of Jsonnet or are having problems installing this.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 $ gem install jsonnet
 ```
 
-By default this gem will compile and install Jsonnet (v0.10.0) as part of
+By default this gem will compile and install Jsonnet (v0.13.0) as part of
 installation. However you can use the system version of Jsonnet if you prefer.
 This would be the recommended route if you want to use a different version
 of Jsonnet or are having problems installing this.

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -13,8 +13,8 @@ unless using_system_libraries?
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
-  recipe = MiniPortile.new('jsonnet', 'v0.13.0')
-  recipe.files = ['https://github.com/google/jsonnet/archive/v0.13.0.tar.gz']
+  recipe = MiniPortile.new('jsonnet', 'v0.16.0')
+  recipe.files = ['https://github.com/google/jsonnet/archive/v0.16.0.tar.gz']
   class << recipe
 
     def compile

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -13,8 +13,8 @@ unless using_system_libraries?
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
-  recipe = MiniPortile.new('jsonnet', 'v0.10.0')
-  recipe.files = ['https://github.com/google/jsonnet/archive/v0.10.0.tar.gz']
+  recipe = MiniPortile.new('jsonnet', 'v0.13.0')
+  recipe.files = ['https://github.com/google/jsonnet/archive/v0.13.0.tar.gz']
   class << recipe
 
     def compile


### PR DESCRIPTION
Release notes:

- https://github.com/google/jsonnet/releases/tag/v0.11.2
- https://github.com/google/jsonnet/releases/tag/v0.12.0
- https://github.com/google/jsonnet/releases/tag/v0.12.1
- https://github.com/google/jsonnet/releases/tag/v0.13.0
- https://github.com/google/jsonnet/releases/tag/v0.14.0
- https://github.com/google/jsonnet/releases/tag/v0.15.0
- https://github.com/google/jsonnet/releases/tag/v0.16.0