### PR TITLE
Include libjsonnet_fmt.h if exists

### DIFF
--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -39,6 +39,7 @@ unless using_system_libraries?
 
       FileUtils.cp(File.join(work_path, 'libjsonnet.a'), lib_path)
       FileUtils.cp(File.join(work_path, 'include', 'libjsonnet.h'), include_path)
+      FileUtils.cp(File.join(work_path, 'include', 'libjsonnet_fmt.h'), include_path)
     end
   end
 
@@ -57,4 +58,5 @@ end
 
 abort 'libjsonnet.h not found' unless have_header('libjsonnet.h')
 abort 'libjsonnet not found' unless have_library('jsonnet')
+have_header('libjsonnet_fmt.h')
 create_makefile('jsonnet/jsonnet_wrap')

--- a/ext/jsonnet/vm.c
+++ b/ext/jsonnet/vm.c
@@ -1,4 +1,7 @@
 #include <libjsonnet.h>
+#ifdef HAVE_LIBJSONNET_FMT_H
+# include <libjsonnet_fmt.h>
+#endif
 #include <ruby/ruby.h>
 #include <ruby/intern.h>
 


### PR DESCRIPTION
fmt function declarations have been moved from libjsonnet.h since
jsonnet v0.12.0.
https://github.com/google/jsonnet/pull/566

This should fix build errors/warnings.
https://travis-ci.org/github/yugui/ruby-jsonnet/builds/704648423