### PR TITLE
Fix linux build

### DIFF
--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -7,6 +7,7 @@ end
 
 dir_config('jsonnet')
 
+RbConfig::MAKEFILE_CONFIG['LDSHARED'] = '$(CXX) -shared'
 unless using_system_libraries?
   message "Building jsonnet using packaged libraries.\n"
   require 'rubygems'

--- a/lib/jsonnet/version.rb
+++ b/lib/jsonnet/version.rb
@@ -1,3 +1,3 @@
 module Jsonnet
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/lib/jsonnet/version.rb
+++ b/lib/jsonnet/version.rb
@@ -1,3 +1,3 @@
 module Jsonnet
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
We are encountering a missing symbol error in Ubuntu 22.04 LTS. 

    irb(main):001:0>require 'jsonnet'
    Traceback (most recent call last):
           13: from /home/parallels/.asdf/installs/ruby/2.7.5/bin/irb:23:in `<main>'
           12: from /home/parallels/.asdf/installs/ruby/2.7.5/bin/irb:23:in `load'
           11: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
           10: from (irb):1
            9: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:147:in `require'
            8: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `rescue in require'
            7: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `require'
            6: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/jsonnet-0.5.0/lib/jsonnet.rb:2:in `<top (required)>'
            5: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
            4: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
            3: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/jsonnet-0.5.0/lib/jsonnet/vm.rb:1:in `<top (required)>'
            2: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
            1: from /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
    LoadError (/home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/jsonnet-0.5.0/lib/jsonnet/jsonnet_wrap.so: undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE - 
    /home/parallels/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/jsonnet-0.5.0/lib/jsonnet/jsonnet_wrap.so)

    $ruby -v
    ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [aarch64-linux]

Did a bit of digging and `_ZTVN10__cxxabiv117__class_type_infoE` decodes as `vtable for __cxxabiv1::__class_type_info` so I assumed we were not linking some important C++ libraries. Changed the link command to use c++ rather than cc and it fixed the issue.