### PR TITLE
Fix fatal errors in Ruby 3.2

### DIFF
--- a/ext/jsonnet/vm.c
+++ b/ext/jsonnet/vm.c
@@ -59,16 +59,15 @@ rubyjsonnet_obj_to_vm(VALUE wrap)
 }
 
 static VALUE
-vm_s_new(int argc, const VALUE *argv, VALUE klass)
+vm_s_allocate(VALUE klass)
 {
     struct jsonnet_vm_wrap *vm;
-    VALUE self = TypedData_Make_Struct(cVM, struct jsonnet_vm_wrap, &jsonnet_vm_type, vm);
+    VALUE self = TypedData_Make_Struct(klass, struct jsonnet_vm_wrap, &jsonnet_vm_type, vm);
     vm->vm = jsonnet_make();
     vm->import_callback = Qnil;
     vm->native_callbacks.len = 0;
     vm->native_callbacks.contexts = NULL;
 
-    rb_obj_call_init(self, argc, argv);
     return self;
 }
 
@@ -390,7 +389,7 @@ void
 rubyjsonnet_init_vm(VALUE mJsonnet)
 {
     cVM = rb_define_class_under(mJsonnet, "VM", rb_cObject);
-    rb_define_singleton_method(cVM, "new", vm_s_new, -1);
+    rb_define_alloc_func(cVM, vm_s_allocate);
     rb_define_private_method(cVM, "eval_file", vm_evaluate_file, 3);
     rb_define_private_method(cVM, "eval_snippet", vm_evaluate, 3);
     rb_define_private_method(cVM, "fmt_file", vm_fmt_file, 2);

--- a/ext/jsonnet/vm.c
+++ b/ext/jsonnet/vm.c
@@ -80,11 +80,10 @@ vm_free(void *ptr)
 
     for (i = 0; i < vm->native_callbacks.len; ++i) {
 	struct native_callback_ctx *ctx = vm->native_callbacks.contexts[i];
-	RB_REALLOC_N(ctx, struct native_callback_ctx, 0);
+	xfree(ctx);
     }
-    RB_REALLOC_N(vm->native_callbacks.contexts, struct native_callback_ctx *, 0);
-
-    RB_REALLOC_N(vm, struct jsonnet_vm_wrap, 0);
+    xfree(vm->native_callbacks.contexts);
+    xfree(vm);
 }
 
 static void

--- a/test/test_vm.rb
+++ b/test/test_vm.rb
@@ -54,7 +54,6 @@ class TestVM < Test::Unit::TestCase
     end
   end
 
-
   test 'Jsonnet::VM#evaluate evaluates snippet' do
     vm = Jsonnet::VM.new
     result = vm.evaluate(<<-EOS, filename: 'example.snippet')


### PR DESCRIPTION
Fixes #33 

* Replace a irregularly defined factory method with an official allocation C API
* Stop using `RB_ALLOC_N(ptr, 0`) to free the pointer.
* Stop using `rb_errinfo()` to distinguish `throw` from `raise`.