### PR TITLE
roll google/jsonnet@v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 $ gem install jsonnet
 ```
 
-By default this gem will compile and install Jsonnet (v0.18.0) as part of
+By default this gem will compile and install Jsonnet (v0.20.0) as part of
 installation. However you can use the system version of Jsonnet if you prefer.
 This would be the recommended route if you want to use a different version
 of Jsonnet or are having problems installing this.

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -13,6 +13,7 @@ unless using_system_libraries?
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
+  # Don't forget to update README.md when rolling new versions
   recipe = MiniPortile.new('jsonnet', 'v0.20.0')
   recipe.files = ['https://github.com/google/jsonnet/archive/v0.20.0.tar.gz']
   class << recipe

--- a/ext/jsonnet/extconf.rb
+++ b/ext/jsonnet/extconf.rb
@@ -13,8 +13,8 @@ unless using_system_libraries?
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 
-  recipe = MiniPortile.new('jsonnet', 'v0.18.0')
-  recipe.files = ['https://github.com/google/jsonnet/archive/v0.18.0.tar.gz']
+  recipe = MiniPortile.new('jsonnet', 'v0.20.0')
+  recipe.files = ['https://github.com/google/jsonnet/archive/v0.20.0.tar.gz']
   class << recipe
     CORE_OBJS = %w[
       desugarer.o formatter.o lexer.o libjsonnet.o parser.o pass.o static_analysis.o string_utils.o vm.o


### PR DESCRIPTION
We need v0.19.0+ for GCC 13 support (otherwise the gem wouldn't build on Arch Linux): https://github.com/google/jsonnet/commit/e43ca8e958d129094bec58fe06a87be1358aaf42

we'd appreciate if you could ship this to rubygems.org after merging